### PR TITLE
fix：修复issue4中的问题1.5.1

### DIFF
--- a/src/main/resources/template/backend/UnitTest.java.vm
+++ b/src/main/resources/template/backend/UnitTest.java.vm
@@ -57,7 +57,7 @@ class ${className}UnitTest {
      */
     @Test
     void testAdminList() {
-        PageResult<${className}BO> pageResult = ${className}Service.adminList(
+        PageResult<${className}BO> pageResult = ${classname}Service.adminList(
                 new PageParam(1, 10),
                 AdminList${className}DTO.builder()
 
@@ -72,7 +72,7 @@ class ${className}UnitTest {
      */
     @Test
     void testAdminInsert() {
-        Long entityId = ${className}Service.adminInsert(
+        Long entityId = ${classname}Service.adminInsert(
                 AdminInsert${className}DTO.builder()
 #foreach ($column in $columns)
 #if($column.columnName != $pk.columnName
@@ -114,7 +114,7 @@ class ${className}UnitTest {
 #end
 #end
                 .build();
-        ${className}Service.adminUpdate(dto);
+        ${classname}Service.adminUpdate(dto);
 
         log.info("\n\n\n更新完成 >> dto={}", dto);
     }
@@ -126,7 +126,7 @@ class ${className}UnitTest {
     void testAdminDelete() {
         // 主键ID列表
         ArrayList<Long> ids = CollUtil.newArrayList(1L, 2L, 3L);
-        ${className}Service.adminDelete(ids);
+        ${classname}Service.adminDelete(ids);
 
         log.info("\n\n\n删除完成 >> ids={}", ids);
     }

--- a/src/main/resources/template/frontend/views/update-drawer.vue.vm
+++ b/src/main/resources/template/frontend/views/update-drawer.vue.vm
@@ -14,7 +14,7 @@
   import {computed, defineComponent, ref, unref} from 'vue';
   import {BasicForm, useForm} from '/@/components/Form/index';
   import {BasicDrawer, useDrawerInner} from '/@/components/Drawer';
-  import {insertOrUpdateFormSchema} from '.data';
+  import {insertOrUpdateFormSchema} from './data';
 
   export default defineComponent({
     name: '${className}UpdateDrawer',

--- a/src/main/resources/template/frontend/views/update-drawer.vue.vm
+++ b/src/main/resources/template/frontend/views/update-drawer.vue.vm
@@ -14,7 +14,7 @@
   import {computed, defineComponent, ref, unref} from 'vue';
   import {BasicForm, useForm} from '/@/components/Form/index';
   import {BasicDrawer, useDrawerInner} from '/@/components/Drawer';
-  import {insertOrUpdateFormSchema} from '/@/views/';
+  import {insertOrUpdateFormSchema} from '.data';
 
   export default defineComponent({
     name: '${className}UpdateDrawer',

--- a/src/main/resources/template/frontend/views/update-drawer.vue.vm
+++ b/src/main/resources/template/frontend/views/update-drawer.vue.vm
@@ -14,6 +14,7 @@
   import {computed, defineComponent, ref, unref} from 'vue';
   import {BasicForm, useForm} from '/@/components/Form/index';
   import {BasicDrawer, useDrawerInner} from '/@/components/Drawer';
+  import { update${className}Api, create${className}Api } from '/@/api/${moduleName}/${className}Api';
   import {insertOrUpdateFormSchema} from './data';
 
   export default defineComponent({


### PR DESCRIPTION
1. 测试并定位到前台报错问题在update-drawer模板第17行: 【没有正确引用到data导致非法访问】
 -- import {insertOrUpdateFormSchema} from '/@/views/';
++ import {insertOrUpdateFormSchema} from './data';
2. 修复后台单元测试模板classname小写引用